### PR TITLE
Feat/113 회원 탈퇴 기능을 구현한다.

### DIFF
--- a/back/src/docs/asciidocs/api-docs.adoc
+++ b/back/src/docs/asciidocs/api-docs.adoc
@@ -87,3 +87,17 @@ operation::tags/update[snippets='http-request,http-response,path-parameters,requ
 === 태그 삭제
 
 operation::tags/delete[snippets='http-request,http-response,path-parameters']
+
+[[resources-user-me]]
+== 유저 조회
+
+operation::user/me[snippets='http-request,http-response,request-fields,response-fields']
+[[resources-user-update]]
+== 유저 수정
+
+operation::user/update[snippets='http-request,http-response,request-fields']
+
+[[resources-user-delete]]
+== 유저 삭제
+
+operation::user/delete[snippets='http-request,http-response,request-headers']

--- a/back/src/main/java/com/cocktailpick/back/user/controller/UserController.java
+++ b/back/src/main/java/com/cocktailpick/back/user/controller/UserController.java
@@ -45,6 +45,14 @@ public class UserController {
 		return ResponseEntity.ok().build();
 	}
 
+	@DeleteMapping("/me")
+	@PreAuthorize("hasRole('USER') or hasRole('ADMIN')")
+	public ResponseEntity<Void> deleteCurrentUser(@CurrentUser User user) {
+		userService.deleteCurrentUser(user);
+
+		return ResponseEntity.noContent().build();
+	}
+
 	@GetMapping("/me/favorites")
 	public ResponseEntity<List<CocktailResponse>> findFavorites(@CurrentUser User user) {
 		return ResponseEntity.ok(userService.findFavorites(user));

--- a/back/src/main/java/com/cocktailpick/back/user/domain/User.java
+++ b/back/src/main/java/com/cocktailpick/back/user/domain/User.java
@@ -12,6 +12,9 @@ import javax.persistence.SequenceGenerator;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
 import com.cocktailpick.back.common.domain.BaseTimeEntity;
 import com.cocktailpick.back.favorite.domain.Favorite;
 import com.cocktailpick.back.favorite.domain.Favorites;
@@ -26,6 +29,8 @@ import lombok.Setter;
 @Entity
 @Getter
 @Setter
+@SQLDelete(sql = "UPDATE user SET deleted=true WHERE id=?")
+@Where(clause = "deleted = false")
 public class User extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_sequence_gen")
@@ -36,7 +41,7 @@ public class User extends BaseTimeEntity {
 	private String name;
 
 	@Email
-	@Column(nullable = false, unique = true)
+	@Column(nullable = false)
 	private String email;
 
 	private String imageUrl;
@@ -57,6 +62,8 @@ public class User extends BaseTimeEntity {
 
 	@Embedded
 	private Favorites favorites = Favorites.empty();
+
+	private boolean deleted;
 
 	@Builder
 	public User(Long id, String name, @Email String email, String imageUrl, Boolean emailVerified, String password,

--- a/back/src/main/java/com/cocktailpick/back/user/service/UserService.java
+++ b/back/src/main/java/com/cocktailpick/back/user/service/UserService.java
@@ -32,6 +32,7 @@ public class UserService {
 		userRepository.deleteById(user.getId());
 	}
 
+	@Transactional(readOnly = true)
 	public List<CocktailResponse> findFavorites(User user) {
 		return user.getFavorites().getFavorites().stream()
 			.map(Favorite::getCocktail)

--- a/back/src/main/java/com/cocktailpick/back/user/service/UserService.java
+++ b/back/src/main/java/com/cocktailpick/back/user/service/UserService.java
@@ -27,6 +27,11 @@ public class UserService {
 	private final FavoriteRepository favoriteRepository;
 	private final CocktailRepository cocktailRepository;
 
+	@Transactional
+	public void deleteCurrentUser(User user) {
+		userRepository.deleteById(user.getId());
+	}
+
 	public List<CocktailResponse> findFavorites(User user) {
 		return user.getFavorites().getFavorites().stream()
 			.map(Favorite::getCocktail)

--- a/back/src/test/java/com/cocktailpick/back/user/acceptance/AuthAcceptanceTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/acceptance/AuthAcceptanceTest.java
@@ -3,25 +3,36 @@ package com.cocktailpick.back.user.acceptance;
 import static com.cocktailpick.back.common.acceptance.step.AcceptanceStep.*;
 import static com.cocktailpick.back.user.acceptance.step.AuthAcceptanceStep.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.cocktailpick.back.common.acceptance.AcceptanceTest;
 import com.cocktailpick.back.user.dto.LoginRequest;
 import com.cocktailpick.back.user.dto.SignUpRequest;
-
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 
 @DisplayName("Auth 인수/통합 테스트")
 public class AuthAcceptanceTest extends AcceptanceTest {
 
+    public static SignUpRequest signUpRequest;
+    public static LoginRequest loginRequest;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        // given
+        signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
+        loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
+    }
+
     @DisplayName("회원가입 요청을 한다.")
     @Test
     public void signUp() {
         // when
-        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
-
         ExtractableResponse<Response> response = requestSignUp(signUpRequest);
 
         // then
@@ -32,13 +43,9 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     public void login() {
         // given
-        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
-
         requestSignUp(signUpRequest);
 
         // when
-        LoginRequest loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
-
         ExtractableResponse<Response> response = requestLogin(loginRequest);
 
         // then

--- a/back/src/test/java/com/cocktailpick/back/user/acceptance/UserAcceptanceTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/acceptance/UserAcceptanceTest.java
@@ -4,6 +4,7 @@ import static com.cocktailpick.back.common.acceptance.step.AcceptanceStep.*;
 import static com.cocktailpick.back.user.acceptance.step.AuthAcceptanceStep.*;
 import static com.cocktailpick.back.user.acceptance.step.UserAcceptanceStep.*;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -18,17 +19,26 @@ import io.restassured.response.Response;
 @DisplayName("User 인수/통합 테스트")
 public class UserAcceptanceTest extends AcceptanceTest {
 
+    public static SignUpRequest signUpRequest;
+    public static LoginRequest loginRequest;
+    public static AuthResponse authResponse;
+
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        // given
+        signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
+        requestSignUp(signUpRequest);
+
+        loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
+        authResponse = requestTokenByLogin(loginRequest);
+    }
+
     @DisplayName("현재 유저의 정보를 조회한다.")
     @Test
     void getUser() {
-        // given
-        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
-
-        requestSignUp(signUpRequest);
-
-        LoginRequest loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
-
-        AuthResponse authResponse = requestTokenByLogin(loginRequest);
 
         // when
         ExtractableResponse<Response> response = requestToGetCurrentUser(authResponse);
@@ -62,14 +72,6 @@ public class UserAcceptanceTest extends AcceptanceTest {
     @DisplayName("현재 유저가 탈퇴한다.")
     @Test
     void deleteUser() {
-        // given
-        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
-
-        requestSignUp(signUpRequest);
-
-        LoginRequest loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
-
-        AuthResponse authResponse = requestTokenByLogin(loginRequest);
 
         // when
         ExtractableResponse<Response> response = requestTodeleteCurrentUser(authResponse);
@@ -81,14 +83,6 @@ public class UserAcceptanceTest extends AcceptanceTest {
     @DisplayName("현재 유저가 탈퇴 후, 동일한 이메일로 회원가입한다.")
     @Test
     void deleteUserSignUp() {
-        // given
-        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
-
-        requestSignUp(signUpRequest);
-
-        LoginRequest loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
-
-        AuthResponse authResponse = requestTokenByLogin(loginRequest);
 
         // when
         ExtractableResponse<Response> response = requestTodeleteCurrentUser(authResponse);
@@ -97,11 +91,15 @@ public class UserAcceptanceTest extends AcceptanceTest {
         assertThatStatusIsNoContent(response);
 
         // given
+        signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
+
+        loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
+
         requestSignUp(signUpRequest);
         AuthResponse reAuthResponse = requestTokenByLogin(loginRequest);
 
         // when
-        ExtractableResponse<Response> getUserResponse = requestToGetCurrentUser(authResponse);
+        ExtractableResponse<Response> getUserResponse = requestToGetCurrentUser(reAuthResponse);
 
         // then
         assertThatStatusIsOk(getUserResponse);

--- a/back/src/test/java/com/cocktailpick/back/user/acceptance/UserAcceptanceTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/acceptance/UserAcceptanceTest.java
@@ -58,4 +58,53 @@ public class UserAcceptanceTest extends AcceptanceTest {
         // then
         assertThatStatusIsOk(updateResponse);
     }
+
+    @DisplayName("현재 유저가 탈퇴한다.")
+    @Test
+    void deleteUser() {
+        // given
+        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
+
+        requestSignUp(signUpRequest);
+
+        LoginRequest loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
+
+        AuthResponse authResponse = requestTokenByLogin(loginRequest);
+
+        // when
+        ExtractableResponse<Response> response = requestTodeleteCurrentUser(authResponse);
+
+        // then
+        assertThatStatusIsNoContent(response);
+    }
+
+    @DisplayName("현재 유저가 탈퇴 후, 동일한 이메일로 회원가입한다.")
+    @Test
+    void deleteUserSignUp() {
+        // given
+        SignUpRequest signUpRequest = new SignUpRequest("그니", "kuenhwi@gmail.com", "그니의 비밀번호");
+
+        requestSignUp(signUpRequest);
+
+        LoginRequest loginRequest = new LoginRequest("kuenhwi@gmail.com", "그니의 비밀번호");
+
+        AuthResponse authResponse = requestTokenByLogin(loginRequest);
+
+        // when
+        ExtractableResponse<Response> response = requestTodeleteCurrentUser(authResponse);
+
+        // then
+        assertThatStatusIsNoContent(response);
+
+        // given
+        requestSignUp(signUpRequest);
+        AuthResponse reAuthResponse = requestTokenByLogin(loginRequest);
+
+        // when
+        ExtractableResponse<Response> getUserResponse = requestToGetCurrentUser(authResponse);
+
+        // then
+        assertThatStatusIsOk(getUserResponse);
+        assertThatGetCurrentUserSuccess(getUserResponse, signUpRequest);
+    }
 }

--- a/back/src/test/java/com/cocktailpick/back/user/acceptance/step/UserAcceptanceStep.java
+++ b/back/src/test/java/com/cocktailpick/back/user/acceptance/step/UserAcceptanceStep.java
@@ -39,8 +39,16 @@ public class UserAcceptanceStep {
             .extract();
     }
 
-    public static void assertThatGetCurrentUserSuccess(ExtractableResponse<Response> response,
-        SignUpRequest signUpRequest) {
+    public static ExtractableResponse<Response> requestTodeleteCurrentUser(AuthResponse authResponse) {
+        return given().log().all()
+            .header(AUTHORIZATION, authResponse.getTokenType() + " " + authResponse.getAccessToken())
+            .when()
+            .delete("/api/user/me")
+            .then().log().all()
+            .extract();
+    }
+
+    public static void assertThatGetCurrentUserSuccess(ExtractableResponse<Response> response, SignUpRequest signUpRequest) {
         UserResponse userResponse = response.as(UserResponse.class);
 
         assertAll(

--- a/back/src/test/java/com/cocktailpick/back/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/controller/UserControllerTest.java
@@ -122,7 +122,8 @@ class UserControllerTest extends DocumentationWithSecurity {
 	void deleteCurrentUser() throws Exception {
 		doNothing().when(userService).deleteCurrentUser(any());
 
-		mockMvc.perform(delete("/api/user/me"))
+		mockMvc.perform(delete("/api/user/me")
+			.header("authorization", "Bearer ADMIN_TOKEN"))
 			.andExpect(status().isNoContent())
 			.andDo(print())
 			.andDo(UserDocumentation.deleteMe());

--- a/back/src/test/java/com/cocktailpick/back/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/controller/UserControllerTest.java
@@ -124,6 +124,7 @@ class UserControllerTest extends DocumentationWithSecurity {
 
 		mockMvc.perform(delete("/api/user/me"))
 			.andExpect(status().isNoContent())
-			.andDo(print());
+			.andDo(print())
+			.andDo(UserDocumentation.deleteMe());
 	}
 }

--- a/back/src/test/java/com/cocktailpick/back/user/controller/UserControllerTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/controller/UserControllerTest.java
@@ -115,4 +115,15 @@ class UserControllerTest extends DocumentationWithSecurity {
 			.andDo(print())
 			.andDo(UserDocumentation.updateUser());
 	}
+
+	@DisplayName("회원 탈퇴한다.")
+	@WithMockCustomUser
+	@Test
+	void deleteCurrentUser() throws Exception {
+		doNothing().when(userService).deleteCurrentUser(any());
+
+		mockMvc.perform(delete("/api/user/me"))
+			.andExpect(status().isNoContent())
+			.andDo(print());
+	}
 }

--- a/back/src/test/java/com/cocktailpick/back/user/docs/UserDocumentation.java
+++ b/back/src/test/java/com/cocktailpick/back/user/docs/UserDocumentation.java
@@ -35,4 +35,10 @@ public class UserDocumentation {
 			)
 		);
 	}
+
+	public static RestDocumentationResultHandler deleteMe() {
+		return document("user/me",
+			requestHeaders(
+				headerWithName("authorization").description("Bearer 토큰")));
+	}
 }

--- a/back/src/test/java/com/cocktailpick/back/user/docs/UserDocumentation.java
+++ b/back/src/test/java/com/cocktailpick/back/user/docs/UserDocumentation.java
@@ -9,7 +9,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 
 public class UserDocumentation {
 	public static RestDocumentationResultHandler findMe() {
-		return document("user/me",
+		return document("user/find",
 			requestHeaders(
 				headerWithName("authorization").description("Bearer 토큰")),
 			responseFields(
@@ -37,7 +37,7 @@ public class UserDocumentation {
 	}
 
 	public static RestDocumentationResultHandler deleteMe() {
-		return document("user/me",
+		return document("user/delete",
 			requestHeaders(
 				headerWithName("authorization").description("Bearer 토큰")));
 	}

--- a/back/src/test/java/com/cocktailpick/back/user/service/UserServiceTest.java
+++ b/back/src/test/java/com/cocktailpick/back/user/service/UserServiceTest.java
@@ -110,4 +110,12 @@ class UserServiceTest {
 
 		assertThat(user.getFavorites().getFavorites().size()).isEqualTo(0);
 	}
+
+	@DisplayName("회원 탈퇴한다.")
+	@Test
+	void deleteCurrentUser() {
+		userService.deleteCurrentUser(user);
+
+		verify(userRepository).deleteById(anyLong());
+	}
 }

--- a/front/src/api/index.js
+++ b/front/src/api/index.js
@@ -79,17 +79,16 @@ export const getCurrentUser = () => {
 export const updateUser = (info) => {
   return client.patch("/api/user/me", info, config);
 };
+export const withdraw = () => {
+  client.delete("/api/user/me", config);
+};
 export const login = (loginRequest) =>
   client.post("/api/auth/login", loginRequest);
 export const signup = (signupRequest) =>
   client.post("/api/auth/signup", signupRequest);
 
 export const fetchMyFavorites = () => {
-  client.get("/api/user/me/favorites", {
-    headers: {
-      Authorization: `Bearer ${localStorage.getItem(ACCESS_TOKEN)}`,
-    },
-  });
+  client.get("/api/user/me/favorites", config);
 };
 
 export const addFavorite = (data) =>

--- a/front/src/component/mypage/MyProfile.js
+++ b/front/src/component/mypage/MyProfile.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Redirect } from "react-router-dom";
-import { useRecoilValue } from "recoil/dist";
+import { useRecoilValue, useSetRecoilState } from "recoil/dist";
 import ProfileImage from "./ProfileImage";
 import ProfileDetail from "./ProfileDetail";
 import "../../css/mypage/profile.css";
@@ -9,6 +9,7 @@ import AdminButton from "./AdminButton";
 
 const MyProfile = () => {
   const { currentUser, authenticated } = useRecoilValue(userState);
+  const setCurrentUser = useSetRecoilState(userState);
 
   const onSubmit = (e) => {
     e.preventDefault();
@@ -27,7 +28,11 @@ const MyProfile = () => {
   return (
     <div className="profile-container">
       <ProfileImage user={currentUser} />
-      <ProfileDetail user={currentUser} onSubmit={onSubmit} />
+      <ProfileDetail
+        user={currentUser}
+        setCurrentUser={setCurrentUser}
+        onSubmit={onSubmit}
+      />
       <AdminButton />
     </div>
   );

--- a/front/src/component/mypage/ProfileDetail.js
+++ b/front/src/component/mypage/ProfileDetail.js
@@ -3,9 +3,11 @@ import Alert from "react-s-alert";
 import { useRecoilValue } from "recoil/dist";
 import { updateUser } from "../../api";
 import ProfileDetailInput from "./ProfileDetailInput";
+import { withdraw } from "../../api";
+import { ACCESS_TOKEN } from "../../constants";
 import { userState } from "../../recoil";
 
-export default () => {
+export default ({ user, setCurrentUser }) => {
   const user = useRecoilValue(userState);
   const [name, setName] = useState(user.currentUser.name);
 
@@ -25,6 +27,13 @@ export default () => {
       .catch((error) => {
         Alert.error("수정에 실패하였습니다.");
       });
+  };
+
+  const userWithdraw = async (e) => {
+    e.preventDefault();
+    await withdraw();
+    setCurrentUser({ currentUser: null, authenticated: false });
+    localStorage.setItem(ACCESS_TOKEN, null);
   };
 
   return (
@@ -51,7 +60,7 @@ export default () => {
           </div>
         </div>
         <div className="withdrawal">
-          <a href="#" onClick={() => alert("hi")} className="withdrawal-submit">
+          <a href="/" onClick={userWithdraw} className="withdrawal-submit">
             회원 탈퇴
           </a>
         </div>


### PR DESCRIPTION
resolve: #113 

현재 회원 탈퇴 후 동일한 이메일로 새로운 계정을 생성할 수 있게 했습니다.

회원 복구 기능을 추가하는 방법과 회원 탈퇴한 이메일로 새로운 계정을 만들지 못하는 방법 등 선택지가 있습니다.

의견을 주시면 좋을 것 같아요 :)